### PR TITLE
NotificationService with Strategy Design Pattern

### DIFF
--- a/EmocineSveikata/EmocineSveikataServer/Program.cs
+++ b/EmocineSveikata/EmocineSveikataServer/Program.cs
@@ -72,7 +72,13 @@ builder.Services.AddScoped<IDiscussionService, DiscussionService>();
 builder.Services.AddScoped<ICommentService, CommentService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IRoomService, RoomService>();
-builder.Services.AddScoped<INotificationService, NotificationService>();
+
+// Notification service using Strategy Design Pattern
+// Utilize it by changing "appsettings.json".NotificationSettings.Type from the default "Regular" to "Hearts" to add hearts to notifications... for the extra user comfort!
+builder.Services.AddScoped<NotificationService>();
+builder.Services.AddScoped<NotificationServiceHearts>();
+builder.Services.AddScoped<INotificationServiceFactory, NotificationServiceFactory>();
+builder.Services.AddScoped(sp => sp.GetRequiredService<INotificationServiceFactory>().Create());
 
 builder.Services.AddAutoMapper(typeof(MapperProfile));
 

--- a/EmocineSveikata/EmocineSveikataServer/Services/NotificationService/INotificationServiceFactory.cs
+++ b/EmocineSveikata/EmocineSveikataServer/Services/NotificationService/INotificationServiceFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace EmocineSveikataServer.Services.NotificationService
+{
+    public interface INotificationServiceFactory
+    {
+        INotificationService Create();
+    }
+}

--- a/EmocineSveikata/EmocineSveikataServer/Services/NotificationService/NotificationServiceFactory.cs
+++ b/EmocineSveikata/EmocineSveikataServer/Services/NotificationService/NotificationServiceFactory.cs
@@ -1,0 +1,25 @@
+﻿namespace EmocineSveikataServer.Services.NotificationService
+{
+    public class NotificationServiceFactory : INotificationServiceFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IConfiguration _configuration;
+
+        public NotificationServiceFactory(IServiceProvider serviceProvider, IConfiguration configuration)
+        {
+            _serviceProvider = serviceProvider;
+            _configuration = configuration;
+        }
+
+        public INotificationService Create()
+        {
+            var type = _configuration["NotificationSettings:Type"];
+            return type switch
+            {
+                "Regular" => _serviceProvider.GetRequiredService<NotificationService>(),
+                "Hearts" => _serviceProvider.GetRequiredService<NotificationServiceHearts>(),
+                _ => throw new InvalidOperationException("Unrecognized notification type in \"appsettings.json\".NotificationSettings")
+            };
+        }
+    }
+}

--- a/EmocineSveikata/EmocineSveikataServer/Services/NotificationService/NotificationServiceHearts.cs
+++ b/EmocineSveikata/EmocineSveikataServer/Services/NotificationService/NotificationServiceHearts.cs
@@ -1,0 +1,39 @@
+﻿using EmocineSveikataServer.Dto;
+
+namespace EmocineSveikataServer.Services.NotificationService
+{
+    public class NotificationServiceHearts : INotificationService
+    {
+        private readonly NotificationService _originalNotificationService;
+
+        public NotificationServiceHearts(NotificationService originalNotificationService)
+        {
+            _originalNotificationService = originalNotificationService;
+        }
+
+        public async Task CreateNotificationAsync(string message, int userId, string link = "")
+        {
+            await _originalNotificationService.CreateNotificationAsync(message, userId, link);
+        }
+
+        public async Task<List<NotificationDto>?> GetNotificationsAsync(int userId)
+        {
+            var notificationDtos = await _originalNotificationService.GetNotificationsAsync(userId);
+
+            if(notificationDtos != null)
+            {
+                foreach(var notification in notificationDtos)
+                {
+                    notification.Message = $"❤️{notification.Message}❤️";
+                }
+            }
+
+            return notificationDtos;
+        }
+
+        public async Task MarkAllAsReadAsync(int userId)
+        {
+            await _originalNotificationService.MarkAllAsReadAsync(userId);
+        }
+    }
+}

--- a/EmocineSveikata/EmocineSveikataServer/appsettings.json
+++ b/EmocineSveikata/EmocineSveikataServer/appsettings.json
@@ -12,5 +12,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "NotificationSettings": {
+    "Type": "Regular"
+  }
 }


### PR DESCRIPTION
Notification service now uses Strategy Design Pattern to pick an alternative notification service without the need to recompile the application.
Utilize it by changing `"appsettings.json".NotificationSettings.Type` from the default `"Regular"` to `"Hearts"` to add hearts to notifications... for the extra user comfort! (Yeah, that was the best I could come up with)